### PR TITLE
fix assets url on html

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/register": "^7.9.0",
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^7.0.0",
+    "babel-jest": "^25.3.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.3",
@@ -59,9 +60,14 @@
     ],
     "coverageDirectory": "./coverage/",
     "transform": {
-      "^.+\\.svelte$": "svelte-jester"
+      "^.+\\.svelte$": "svelte-jester",
+      "^.+\\.js$": "babel-jest"
     },
-    "moduleFileExtensions": ["js", "svelte"]
+    "moduleFileExtensions": [
+      "js",
+      "svelte"
+    ],
+    "testMatch": ["**/**/*.test.js"]
   },
   "prettier": {
     "printWidth": 100,

--- a/public/index.html
+++ b/public/index.html
@@ -22,10 +22,10 @@
   <title>Cidades do Paraná</title>
 
   <link rel="icon" type="image/png" href="https://jlozovei.github.io/cidades-do-parana/favicon.png" sizes="96x96">
-  
-  <link rel="stylesheet" href="/global.css">
-  <link rel="stylesheet" href="/build/bundle.css">
-  <script defer src="/build/bundle.js"></script>
+
+  <link rel="stylesheet" href="https://jlozovei.github.io/cidades-do-parana/global.css">
+  <link rel="stylesheet" href="https://jlozovei.github.io/cidades-do-parana/build/bundle.css">
+  <script defer src="https://jlozovei.github.io/cidades-do-parana/build/bundle.js"></script>
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -23,9 +23,9 @@
 
   <link rel="icon" type="image/png" href="https://jlozovei.github.io/cidades-do-parana/favicon.png" sizes="96x96">
 
-  <link rel="stylesheet" href="https://jlozovei.github.io/cidades-do-parana/global.css">
-  <link rel="stylesheet" href="https://jlozovei.github.io/cidades-do-parana/build/bundle.css">
-  <script defer src="https://jlozovei.github.io/cidades-do-parana/build/bundle.js"></script>
+  <link rel="stylesheet" href="./global.css">
+  <link rel="stylesheet" href="./build/bundle.css">
+  <script defer src="./build/bundle.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
#### What is the goal of this change?
Fix assets' URL on `index.html`.

#### Is there any issue related?
The assets aren't loading due to the wrong relative URL, with my github subdomain.

#### How does the changes address the issue?
Putting the absolute URL to the assets path should solve the problem.
